### PR TITLE
Prevent from failing when value is null

### DIFF
--- a/src/Newtonsoft.Json.Encryption/Encrypter.cs
+++ b/src/Newtonsoft.Json.Encryption/Encrypter.cs
@@ -25,6 +25,8 @@ namespace Newtonsoft.Json.Encryption
 
         public string Encrypt(string target)
         {
+            
+            
             var encryptor = encryptProvider();
             try
             {
@@ -45,6 +47,8 @@ namespace Newtonsoft.Json.Encryption
 
         public string Decrypt(string value)
         {
+            if (value == null) return string.Empty;
+            
             var decryptor = decryptProvider();
             var encrypted = Convert.FromBase64String(value);
             try


### PR DESCRIPTION
Decrypt function was failling when a value vas null

Where it is clear the below content has not read, the issue is likely to be closed with "please read the template". Please don't take offense at this. It is simply a time management decision. When someone raises an issue, without reading the template, then often too much time is spent going back and forth to obtain information that is outlined below.


#### You should already be a Patron

To be using this library you should be a [Patron of NServiceBusExtensions](https://opencollective.com/nservicebusextensions/order/6976). With that in mind, it is assumed anyone raising a PR is already a Patron. As such your GitHub Id may be verified against the [OpenCollective contributors](https://opencollective.com/nservicebusextensions#contributors). This process will depend on the PR quality, your circumstances, and the impact on the larger user base.


#### Guidance

If you are uncertain if the PR will be accepted, outline the proposal in an issue to confirm it is viable.

Even if the feature is a good idea and viable, it may not be accepted since the ongoing effort in maintaining the feature may outweigh the benefit it delivers.


#### Description

A description of what the PR achieves.


#### The solution

Outline the implementation. Also include any alternative solutions considered.


#### Todos

 * [ ] Related issues
 * [ ] Tests
 * [ ] Documentation